### PR TITLE
Added Append parameter and updated REGEX to support parameters in translation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ By default name of lang file is `lang`
 
 In addition, the command accepts several parameters that allow you to flexibly manage the package.
 ```
-php artisan lang:generate --type= --name= --langs= --sync --clear --path=
+php artisan lang:generate --type= --name= --langs= --sync --clear --append --path=
 ```
 ### About parameters 
 
@@ -102,6 +102,16 @@ If you specify this flag, existing language files are removed and new ones are c
 `NOTE! That NOT all language files are deleted, but only with the name specified in the settings.`
 
 Example: `php artisan lang:generate --clear`
+
+---
+
+`--append` or `-A`:
+
+If you specify this flag, new translations found will be added at the end of the JSON file, which might be useful for automatisation or version control. Only usable with JSON as type.
+
+`NOTE! USing this without JSON as the type will not work!`
+
+Example: `php artisan lang:generate --type=json --append`
 
 ## Notes
 `lang:generate` will update your language files by writing them completely, meaning that any comments or special styling will be removed, so I recommend you backup your files.

--- a/README.md
+++ b/README.md
@@ -109,8 +109,6 @@ Example: `php artisan lang:generate --clear`
 
 If you specify this flag, new translations found will be added at the end of the JSON file, which might be useful for automatisation or version control. Only usable with JSON as type.
 
-`NOTE! USing this without JSON as the type will not work!`
-
 Example: `php artisan lang:generate --type=json --append`
 
 ## Notes

--- a/src/Commands/LangGeneratorCommand.php
+++ b/src/Commands/LangGeneratorCommand.php
@@ -37,9 +37,10 @@ class LangGeneratorCommand extends Command
         $this->manager->languages = $this->option('langs') ?: $this->manager->languages;
         $this->manager->path = $this->option('path');
 
-        if($this->manager->doAppend === true && $this->manager->fileType !== 'json') {
+        if ($this->manager->doAppend === true && $this->manager->fileType !== 'json') {
             $this->error('The append option is only possible for type json.');
-			return;
+
+            return;
         }
         
         if ($this->manager->isNew) {

--- a/src/Commands/LangGeneratorCommand.php
+++ b/src/Commands/LangGeneratorCommand.php
@@ -39,7 +39,7 @@ class LangGeneratorCommand extends Command
 
         if($this->manager->doAppend === true && $this->manager->fileType !== 'json') {
             $this->error('The append option is only possible for type json.');
-			returnl
+			return;
         }
         
         if ($this->manager->isNew) {

--- a/src/Commands/LangGeneratorCommand.php
+++ b/src/Commands/LangGeneratorCommand.php
@@ -7,7 +7,7 @@ use Illuminate\Console\Command;
 
 class LangGeneratorCommand extends Command
 {
-    protected $signature = 'lang:generate {--T|type=} {--N|name=} {--L|langs=*} {--S|sync} {--C|clear} {--P|path=}';
+    protected $signature = 'lang:generate {--T|type=} {--N|name=} {--L|langs=*} {--S|sync} {--C|clear} {--P|path=} {--A|append}';
 
     protected $description = 'Searches for multilingual phrases in Laravel project and automatically generates language files for you.';
 
@@ -30,12 +30,18 @@ class LangGeneratorCommand extends Command
         //Get user input configs
         $this->manager->isSync = $this->option('sync');
         $this->manager->isNew = $this->option('clear');
+        $this->manager->doAppend = $this->option('append');
 
         $this->manager->fileType = $this->option('type') ?: $this->manager->fileType;
         $this->manager->fileName = $this->option('name') ?: $this->manager->fileName;
         $this->manager->languages = $this->option('langs') ?: $this->manager->languages;
         $this->manager->path = $this->option('path');
 
+        if($this->manager->doAppend === true && $this->manager->fileType !== 'json') {
+            $this->error('The append option is only possible for type json.');
+			returnl
+        }
+        
         if ($this->manager->isNew) {
             if ($this->confirm('You really want to generate new language files? This will clear all existing files!')) {
                 $this->manager->parseProject();

--- a/src/Commands/LangGeneratorCommand.php
+++ b/src/Commands/LangGeneratorCommand.php
@@ -42,7 +42,7 @@ class LangGeneratorCommand extends Command
 
             return;
         }
-        
+
         if ($this->manager->isNew) {
             if ($this->confirm('You really want to generate new language files? This will clear all existing files!')) {
                 $this->manager->parseProject();

--- a/src/LangService.php
+++ b/src/LangService.php
@@ -160,7 +160,7 @@ class LangService extends Command
     {
         $fileData = file_get_contents($path);
 
-        $re = '/@lang\(\'(.+?)\'\)|trans\(\'(.+?)\'\)|__\(\'(.+?)\'\)/m';
+        $re = '/@lang\(\'(.+?)\'(?:,\s{0,16}\[.{1,256}\]){0,1}\)|trans\(\'(.+?)\'(?:,\s{0,16}\[.{1,256}\]){0,1}\)|__\(\'(.+?)\'(?:,\s{0,16}\[.{1,256}\]){0,1}\)/m';
         preg_match_all($re, $fileData, $matches, PREG_SET_ORDER, 0);
 
         $data = [];

--- a/src/LangService.php
+++ b/src/LangService.php
@@ -249,7 +249,7 @@ class LangService extends Command
 
                     foreach ($dataArr as $key => $value) {
                         if(!isset($tempArray[$key])) {
-                            $tempArray[$key] = $value;
+                            $tempArray[$key] = $key;
                         }
                     }
 

--- a/src/LangService.php
+++ b/src/LangService.php
@@ -243,8 +243,8 @@ class LangService extends Command
         if ($this->fileType === 'json') {
             if (file_exists($path)) {
                 $existingArr = json_decode(file_get_contents($path), true);
-                
-                if($this->doAppend) {
+
+                if ($this->doAppend) {
                     $tempArray = $existingArr;
 
                     foreach ($dataArr as $key => $value) {

--- a/src/LangService.php
+++ b/src/LangService.php
@@ -9,7 +9,7 @@ class LangService extends Command
     public $isSync = false;
     public $isNew = false;
     public $doAppend = false;
-    
+
     public $viewsFilesCount = 0;
     public $viewsKeysCount = 0;
     public $appFilesCount = 0;
@@ -248,7 +248,7 @@ class LangService extends Command
                     $tempArray = $existingArr;
 
                     foreach ($dataArr as $key => $value) {
-                        if(!isset($tempArray[$key])) {
+                        if (!isset($tempArray[$key])) {
                             $tempArray[$key] = $key;
                         }
                     }
@@ -350,7 +350,7 @@ class LangService extends Command
     /**
      * Fill Array language file.
      *
-     * @param $fileName
+     * @param       $fileName
      * @param array $keys
      *
      * @return void
@@ -388,7 +388,7 @@ class LangService extends Command
     /**
      * Write translation keys to a .php arrays.
      *
-     * @param $filePath
+     * @param       $filePath
      * @param array $translations
      *
      * @return void

--- a/src/LangService.php
+++ b/src/LangService.php
@@ -258,6 +258,7 @@ class LangService extends Command
                     foreach ($existingArr as $key => $value) {
                         $dataArr[$key] = $value;
                     }
+
                     return $dataArr;
                 }
             }

--- a/src/LangService.php
+++ b/src/LangService.php
@@ -8,7 +8,8 @@ class LangService extends Command
 {
     public $isSync = false;
     public $isNew = false;
-
+    public $doAppend = false;
+    
     public $viewsFilesCount = 0;
     public $viewsKeysCount = 0;
     public $appFilesCount = 0;
@@ -242,12 +243,23 @@ class LangService extends Command
         if ($this->fileType === 'json') {
             if (file_exists($path)) {
                 $existingArr = json_decode(file_get_contents($path), true);
+                
+                if($this->doAppend) {
+                    $tempArray = $existingArr;
 
-                foreach ($existingArr as $key => $value) {
-                    $dataArr[$key] = $value;
+                    foreach ($dataArr as $key => $value) {
+                        if(!isset($tempArray[$key])) {
+                            $tempArray[$key] = $value;
+                        }
+                    }
+
+                    return $tempArray;
+                } else {
+                    foreach ($existingArr as $key => $value) {
+                        $dataArr[$key] = $value;
+                    }
+                    return $dataArr;
                 }
-
-                return $dataArr;
             }
 
             foreach ($dataArr as $key => $value) {


### PR DESCRIPTION
Added the --append parameter, only usable with the JSON type. This causes newfound translations to be put at the end of the JSON file, instead of just where it was found. It can be useful for automatisation purposes.

Also updated the regex in use to support parameters in translation strings, like the laravel docs example:
`echo __('messages.welcome', ['name' => 'dayle']);`